### PR TITLE
Ensure ward linkage supported and document all clustering modes

### DIFF
--- a/R/cluster.R
+++ b/R/cluster.R
@@ -16,7 +16,9 @@ NULL
 #' @param min_value Minimum 'Pvalue' a term must have in order to be counted in final clustering
 #' @param distance_metric A string specifying the distance metric to use (e.g., "kappa").
 #' @param distance_cutoff A numeric value for the distance cutoff (0 < cutoff <= 1).
-#' @param linkage_method A string specifying the merge strategy to use (e.g., "DAVID").
+#' @param linkage_method A string specifying the linkage method to use
+#'        (e.g., "average"). Supported options are "single", "complete",
+#'        "average", and "ward".
 #' @param linkage_cutoff A numeric value between 0 and 1 for the membership cutoff.
 #'
 #' @return A named list containing:
@@ -82,7 +84,7 @@ cluster <- function(enrichment_results, df_names=NULL, min_terms=5, min_value=0.
 
 validate_inputs <- function(enrichment_results, df_names=NA_character_,
                             distance_metric="kappa", distance_cutoff=0.5,
-                            linkage_method="DAVID", linkage_cutoff=0.5) {
+                            linkage_method="average", linkage_cutoff=0.5) {
   if (!is.list(enrichment_results)) {
     stop("enrichment_results must be a list of dataframes.")
   }
@@ -98,8 +100,8 @@ validate_inputs <- function(enrichment_results, df_names=NA_character_,
   if (distance_metric != "kappa" && distance_metric != "jaccard") {
     stop("Unsupported distance metric. Only 'kappa' and 'jaccard' are supported.")
   }
-  if (linkage_method != "single" && linkage_method != "complete" && linkage_method != "average") {
-    stop("Unsupported linkage_method. Only 'single', 'complete', and 'average' is supported.")
+  if (!linkage_method %in% c("single", "complete", "average", "ward")) {
+    stop("Unsupported linkage_method. Only 'single', 'complete', 'average', and 'ward' are supported.")
   }
 
 }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ After an initial grouping of terms based on having a distance score above a cert
 
 The default recommended should be `average`, which takes the average distance between all terms in the two clusters and uses that as the metric to merge.
 
-The total list of supported metrics includes: 
+The full list of supported linkage methods includes:
 - `"single"`
 - `"complete"`
 - `"average"`

--- a/scripts/tests.R
+++ b/scripts/tests.R
@@ -37,6 +37,26 @@ ward_cluster_result <- richCluster::cluster(
 print("Ward linkage clustering successful:")
 print(head(ward_cluster_result$final_clusters))
 
+# SINGLE LINKAGE TEST
+# ---
+single_cluster_result <- richCluster::cluster(
+  cluster_result$df_list, df_names=cluster_result$df_names, min_terms=3, min_value=0.0001,
+  distance_metric="kappa", distance_cutoff=0.5,
+  linkage_method="single", linkage_cutoff=0.5
+)
+print("Single linkage clustering successful:")
+print(head(single_cluster_result$final_clusters))
+
+# COMPLETE LINKAGE TEST
+# ---
+complete_cluster_result <- richCluster::cluster(
+  cluster_result$df_list, df_names=cluster_result$df_names, min_terms=3, min_value=0.0001,
+  distance_metric="kappa", distance_cutoff=0.5,
+  linkage_method="complete", linkage_cutoff=0.5
+)
+print("Complete linkage clustering successful:")
+print(head(complete_cluster_result$final_clusters))
+
 # DAVID CLUSTER TEST
 # ---
 david_cluster_result <- richCluster::david_cluster(


### PR DESCRIPTION
## Summary
- Expand clustering validation to document and accept the `ward` linkage mode alongside `single`, `complete`, and `average`
- Exercise each linkage type (ward, single, complete) in the test script for comprehensive coverage
- Document full list of supported linkage methods in README

## Testing
- `Rscript scripts/tests.R` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68b87dc01d348333a5e899c722cf4112