### PR TITLE
Fix geneID conversion when counting unique elements in DavidClustering

### DIFF
--- a/src/DavidClustering.cpp
+++ b/src/DavidClustering.cpp
@@ -17,7 +17,10 @@ DavidClustering::DavidClustering(
     multipleLinkageThreshold(multipleLinkageThreshold) {
 
     n_terms = terms.size();
-    totalGeneCount = StringUtils::countUniqueElements(geneIDs);
+    // Convert the incoming CharacterVector of comma-separated gene IDs to a
+    // standard vector so StringUtils utilities can operate on it.
+    std::vector<std::string> geneIDsVector = Rcpp::as<std::vector<std::string>>(geneIDs);
+    totalGeneCount = StringUtils::countUniqueElements(geneIDsVector);
     kappaMatrix.resize(n_terms, std::vector<double>(n_terms, 0.0));
 }
 


### PR DESCRIPTION
## Summary
- convert the incoming CharacterVector of gene IDs to a std::vector before counting unique elements so the StringUtils helper receives the expected type

## Testing
- Rscript -e "devtools::check()" *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68ceebe22f8c833389048be7ab3a4810